### PR TITLE
Try trusty; check if hhvm checks pass then

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.3
   - 5.4


### PR DESCRIPTION
hhvm tests don't run for smarty at the moment; switching to trusty might change that (it's suggested by the travis.ci test-report).